### PR TITLE
remove member '__unused' from struct

### DIFF
--- a/src/icmp.c
+++ b/src/icmp.c
@@ -258,7 +258,6 @@ int icmp_send_frag_needed(int fd, struct sockaddr *to, int tolen,
 	icp->type = ICMP_DEST_UNREACH;
 	icp->code = ICMP_FRAG_NEEDED;
 	icp->checksum = 0;
-	icp->un.frag.__unused = 0;
 	icp->un.frag.mtu = htons(newmtu);
 
 	/* copy ip header + 64-bits of original packet */


### PR DESCRIPTION
@ncopa 
Hello, I have the following issue during compile time:

```
cc -march=native -O2 -pipe -mmmx -msse4.2 -mssse3 -mfpmath=sse -fomit-frame-pointer -Wall -DHAVE_CONFIG_H -I../ -DPINGU_VERSION=\"\" -Wall -Wstrict-prototypes -D_GNU_SOURCE -std=gnu99 -DDEFAULT_PIDFILE=\"/run/pingu/pingu.pid\" -DDEFAULT_CONFIG=\"/usr/etc/pingu/pingu.conf\" -DDEFAULT_ADM_client=\"/run/pingu/pingu.ctl\"  -c icmp.c
icmp.c: In function 'icmp_send_frag_needed':
icmp.c:261:14: error: 'struct <anonymous>' has no member named '__unused'
  icp->un.frag.__unused = 0;
              ^
make: *** [Makefile:82: icmp.o] Error 1
```

It looks like `icp->un.frag.__unused = 0;` shouldn't be there. Could you check this, please?